### PR TITLE
Add Rocky 9 supported version (codename Blue Onyx)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,12 +52,12 @@ glpi_agent__package_name:
 # eg for version **1.5** :
 # https://github.com/glpi-project/glpi-agent/releases/download/1.5/glpi-agent_1.5-1_all.deb
 # Default value:
-glpi_agent__package_url: '{{ "https://github.com/glpi-project/glpi-agent/releases/download/"
-                           + glpi_agent__major_version
-                           + "/glpi-agent_"
-                           + glpi_agent__version
-                           + "_all.deb" if (ansible_os_family in ["Debian"])
-                                        else "" }}'
+glpi_agent__package_url: >-
+  {%- if (ansible_os_family in ["Debian"]) -%}
+  https://github.com/glpi-project/glpi-agent/releases/download/{{ glpi_agent__major_version }}/glpi-agent_{{ glpi_agent__version }}_all.deb
+  {%- elif (ansible_os_family in ["RedHat"]) -%}
+  https://github.com/glpi-project/glpi-agent/releases/download/{{ glpi_agent__major_version }}/glpi-agent-{{ glpi_agent__version }}.noarch.rpm
+  {%- endif -%}
 # ]]]
 
 #### glpi_agent__depends [[[

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,9 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - jammy
+    - name: Rocky
+      versions:
+        - Blue Onyx
   galaxy_tags:
     - glpi
     - agent

--- a/tasks/Rocky.yml
+++ b/tasks/Rocky.yml
@@ -1,0 +1,27 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+#
+# tasks file for Rocky
+
+# Install GLPI Agent from remote .rpm file [[[1
+# dnf module can download a .rpm file
+# Package perl(Net::IP), perl(Parallel::ForkManager), perl(Proc::Daemon), perl(Socket::GetAddrInfo), perl(UNIVERSAL::require) are in EPEL
+- name: Ensure the EPEL repository is enabled
+  ansible.builtin.dnf:
+    name: epel-release
+    state: present
+  when:
+    - glpi_agent__install_from_url | bool
+
+# Package perl(DateTime), perl(Data::UUID), perl(HTTP::Daemon), perl(YAML::Tiny) are in crb repo
+# `disable_gpg_check: true` fix this issue: Failed to validate GPG signature for glpi-agent-1.11-1.noarch: Package glpi-agent-1.11-1.noarch5pzw3667.rpm is not signed
+- name: Ensure GLPI Agent package from URL
+  ansible.builtin.dnf:
+    name: '{{ glpi_agent__package_url }}'
+    state: present
+    enablerepo: crb
+    disable_gpg_check: true
+  register: ga_url_pkg_result
+  until: ga_url_pkg_result is success
+  when:
+    - glpi_agent__install_from_url | bool

--- a/vars/Rocky.yml
+++ b/vars/Rocky.yml
@@ -1,0 +1,95 @@
+---
+# .. vim: foldmarker=[[[,]]]:foldmethod=marker
+
+# .. Syntax [[[
+# .. This file is used by a script to generate the README.md file.
+# .. Any line starting with "# .." will be ignored by the script.
+# .. Some other patterns will also be ignored ("---", "# \]\]\]",…).
+# .. If you don't know how-to manage, simply duplicate the content of an
+# .. existing variable.
+# .. ]]]
+
+## Rocky dedicated variables
+
+# These variables can't be overrided by the user.
+
+### Packages and installation for Rocky [[[
+
+#### Rocky glpi_agent__depends_packages [[[
+# **List**. Dependencies for GLPI Agent package.
+# * Based on `yum repoquery --deplist ` output for .rpm package version **1.11-1**.
+# * To skip the installation of these packages,
+#   see [glpi_agent__depends](#glpi_agent__depends) above.
+# Default value:
+glpi_agent__depends_packages:
+  - perl-base
+  - perl-constant
+  - perl-Cpanel-JSON-XS
+  - perl-Digest-SHA
+  - perl-Encode
+  - perl-English
+  - perl-Exporter
+  - perl-Fcntl
+  - perl-File-Basename
+  - perl-File-Find
+  - perl-File-Path
+  - perl-File-stat
+  - perl-File-Temp
+  - perl-File-Which
+  - perl-Getopt-Long
+  - perl-HTTP-Cookies
+  - perl-HTTP-Message
+  - perl-interpreter
+  - perl-IO
+  - perl-IO-Compress
+  - perl-IO-Socket-SSL
+  - perl-lib
+  - perl-libwww-perl
+  - perl-LWP-Protocol-https
+  - perl-MIME-Base64
+  - perl-Net
+  - perl-Net-HTTP
+  - perl-Net-IP
+  - perl-Net-SSLeay
+  - perl-Parallel-ForkManager
+  - perl-parent
+  - perl-PathTools
+  - perl-Pod-Usage
+  - perl-POSIX
+  - perl-Proc-Daemon
+  - perl-Socket
+  - perl-Socket-GetAddrInfo
+  - perl-Storable
+  - perl-Sys-Hostname
+  - perl-Sys-Syslog
+  - perl-Text-Template
+  - perl-threads
+  - perl-Thread-Semaphore
+  - perl-threads-shared
+  - perl-Time-HiRes
+  - perl-Time-Local
+  - perl-UNIVERSAL-require
+  - perl-URI
+  - perl-vars
+  - perl-XML-LibXML
+# ]]]
+
+#### Rocky glpi_agent__recommends_packages [[[
+# **List**. Recommandations for GLPI Agent package.
+# * Based on `yum repoquery --deplist` output for .rpm package version **1.11-1**.
+# * To skip the installation of these packages,
+#   see [glpi_agent__recommends](#glpi_agent__recommends) above.
+# Default value:
+glpi_agent__recommends_packages:
+# ]]]
+
+#### Rocky glpi_agent__suggests_packages [[[
+# **List**. Suggestions for GLPI Agent package.
+# * Based on `yum repoquery --deplist` output for .rpm package version **1.5-1**.
+# * To skip the installation of these packages,
+#   see [glpi_agent__suggests](#glpi_agent__suggests) above.
+# Default value:
+glpi_agent__suggests_packages:
+# ]]]
+
+### ]]]


### PR DESCRIPTION
Hi  Jérémy (@gardouille ),

please found a Pull Request to add support for Rocky 9 version (tested on a fresh installed lxc container)

It's only installable via `Ensure GLPI Agent package from URL` as i don't find any repository available for it , ... 

i have change the syntax of  `glpi_agent__package_url` in (default/main.yml) as i wasn't able to use `else if condition` and in rpm package file it's a `-` instead of `_` in the name of the package